### PR TITLE
Feature improve person mints

### DIFF
--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -281,7 +281,7 @@ type Query {
   mintMaterials: [MintMaterials]
   getMaterialColor(id: ID!): String
 
-  getPersonMints: [MintPersons]
+  getPersonMints(mints: [ID], persons:[ID]): [MintPersons]
 
   province: [Name]
   searchProvince(text: String): [Name]

--- a/backend/src/utils/database.js
+++ b/backend/src/utils/database.js
@@ -3,7 +3,7 @@ require("dotenv").config()
 const pgp = require("pg-promise")({
     // This logs the queries that are executed
     query: function (e) {
-        // console.log(e.query);
+        console.log(e.query);
     }
 })
 

--- a/backend/src/utils/database.js
+++ b/backend/src/utils/database.js
@@ -3,7 +3,7 @@ require("dotenv").config()
 const pgp = require("pg-promise")({
     // This logs the queries that are executed
     query: function (e) {
-        console.log(e.query);
+        //console.log(e.query);
     }
 })
 

--- a/frontend/src/components/MintList.vue
+++ b/frontend/src/components/MintList.vue
@@ -31,6 +31,7 @@
             :style="{ color: item.color, borderColor: item.color }"
           >
             <span>{{ item.name }}</span>
+            <span v-if="$store.state.debug">{{ item.id }}</span>
           </MultiSelectListItem>
         </ul>
       </Collapsible>
@@ -44,7 +45,6 @@ import MultiSelectListItem from './MultiSelectListItem.vue';
 import MultiSelectListMixin from './mixins/multi-select-list.js';
 
 import CollapsibleListMixin from './mixins/collapsible-list.js';
-
 
 import Collapsible from './layout/Collapsible.vue';
 import Sort from '../utils/Sorter';
@@ -63,8 +63,7 @@ export default {
     ListSelectionTools,
     SelectableListHeader,
   },
-  mixins: [MultiSelectListMixin,
-  CollapsibleListMixin],
+  mixins: [MultiSelectListMixin, CollapsibleListMixin],
   methods: {
     toggleAllProvince(group) {
       if (this.allSelected(group)) {
@@ -73,7 +72,6 @@ export default {
         this.removeAllFromGroup(group);
       }
     },
-
   },
 
   computed: {
@@ -87,7 +85,7 @@ export default {
           groups[province] = {
             id,
             name: province,
-            items: []
+            items: [],
           };
         }
         groups[province].items.push(mint);

--- a/frontend/src/components/RulerListSection.vue
+++ b/frontend/src/components/RulerListSection.vue
@@ -19,6 +19,7 @@
       </template>
       <span
         >{{ getRulerName(item) }}
+        {{ $store.state.debug ? ` (${item.id})` : '' }}
         <span v-if="getDynasty(item)" class="dynasty">{{
           getDynasty(item)
         }}</span></span

--- a/frontend/src/components/navigation/Breadcrumbs.vue
+++ b/frontend/src/components/navigation/Breadcrumbs.vue
@@ -38,7 +38,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+$crumb-background-color: $white;
+
 .breadcrumbs {
+  position: relative;
   padding: $padding;
   display: flex;
   max-width: 100%;
@@ -46,8 +49,6 @@ export default {
 }
 
 .crumb {
-  $color: $white;
-
   @mixin common {
     content: '';
     height: 0;
@@ -63,7 +64,7 @@ export default {
 
   a {
     color: $gray;
-    background-color: $color;
+    background-color: $crumb-background-color;
     padding: $padding;
   }
 
@@ -77,15 +78,15 @@ export default {
     &:before {
       @include common;
       border-right-width: 0;
-      border-top-color: $color;
-      border-bottom-color: $color;
+      border-top-color: $crumb-background-color;
+      border-bottom-color: $crumb-background-color;
     }
   }
 
   &:after {
     @include common;
     border-right-width: 0;
-    border-left-color: $color;
+    border-left-color: $crumb-background-color;
   }
 
   &:last-child {
@@ -95,7 +96,7 @@ export default {
     &:after {
       @include common;
       border-right-width: 17px;
-      border-color: $color;
+      border-color: $crumb-background-color;
       border-top-right-radius: 17px;
       border-bottom-right-radius: 17px;
     }

--- a/frontend/src/components/navigation/Card.vue
+++ b/frontend/src/components/navigation/Card.vue
@@ -47,12 +47,6 @@ export default {
     z-index: 100;
   }
 
-  &:hover {
-    header {
-      min-height: 100%;
-    }
-  }
-
   // filter: grayscale(50%);
 }
 
@@ -66,7 +60,6 @@ export default {
     box-sizing: border-box;
     padding: $padding * 2;
     background-color: rgba($primary-color, 0.75);
-    transition: min-height $transition-time;
     backdrop-filter: blur(3px);
   }
 }

--- a/frontend/src/maps/PoliticalOverlay.js
+++ b/frontend/src/maps/PoliticalOverlay.js
@@ -315,7 +315,7 @@ export default class PoliticalOverlay extends Overlay {
     if (data.length > 0 && (!this.isSelectionActive(selection) || isMintSelected)) {
       const concentricCirclesMarker = concentricCircles(latlng, data, {
         openPopup: function ({ data, groupData }) {
-          return rulerPopup(groupData, data?.data, true);
+          return rulerPopup(groupData, data?.data);
         },
         innerRadius: MintLocationMarker.defaultSize,
         radius: this.settings.settings.maxRadius,
@@ -334,7 +334,7 @@ export default class PoliticalOverlay extends Overlay {
        * was intentionally removed by request of the numismatics 
        * //14-12-2022
        */
-      const locationMarker = this.createMintLocationMarker(latlng, feature, /* {active: isMintSelected} */)
+      const locationMarker = this.createMintLocationMarker(latlng, feature)
       const objects = [concentricCirclesMarker, locationMarker]
 
 
@@ -344,7 +344,7 @@ export default class PoliticalOverlay extends Overlay {
 
       layer = L.featureGroup(objects);
     } else {
-      layer = this.createMintLocationMarker(latlng, feature, /* {active: isMintSelected} */)
+      layer = this.createMintLocationMarker(latlng, feature)
       layer.bringToBack()
     }
 

--- a/frontend/src/models/map/mint.js
+++ b/frontend/src/models/map/mint.js
@@ -19,9 +19,12 @@ export default class Mint {
         })
     }
 
-    static popupMintHeader(mint, headerClasses = []) {
+    static popupMintHeader(mint, headerClasses = [], debug = false) {
         return `<header class="${headerClasses.join(" ")}">
-            <span class="subtitle no-padding-bottom">${mint.name}</span>    
+            <span class="subtitle no-padding-bottom">${mint.name}
+            ${(window.debug) ? `  (${mint.id})` : ''}
+            
+            </span>    
             ${(mint.uncertain) ? `
         <div class="uncertain-info"> 
             (genaue) Lokalisierung unsicher
@@ -29,8 +32,10 @@ export default class Mint {
            `
                 : ""
             }
+
+            ${(window.debug) ? `${mint.province.name} (${mint.province.id})` : ''} 
         
-       
+        
         </header > `
     }
 
@@ -38,12 +43,12 @@ export default class Mint {
         return `mint {
             id
             name
-            location 
+            location
             uncertain
             province {
-              id
-              name
+                id
+                name
             }
-          }`
+        } `
     }
 }


### PR DESCRIPTION
Modified getPersonMints (which is used for the political ap without time), 
introducing inconsistencies with the data basis
Which was requested by the numismatics department:
Issuers are a own 'class' (by having their own table and are recorded independently)
and are neither related with the overlords nor the caliphs (in the data).
Now we treat coins that have no issuers but a caliph in the way, that the getPersonMints returns the caliphs
of those coins also as issuers.  